### PR TITLE
Feature/generalize api url

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,19 @@
 Changelog
 =========
 
+0.3.0 (2018-04-13)
+------------------
+
+* Feature: accept to pass api_url
+* Feature: determine api url if catalog provide incomplete one (eg. without version)
+
+
+0.2.3 (2018-04-05)
+------------------
+
+* Bugfix: do_not_await_sync_method
+
+
 0.2.2 (2018-04-02)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -40,8 +40,13 @@ As mentioned above this is "raw" library, so you must handle `params` and/or `bo
         user_domain_name='default',
         project_domain_name='foo.bar'
     )
-    nova = NovaClient(API_VERSION, session=auth)
+    nova = NovaClient(session=auth)
     glance = GlanceClient(session=auth)
+
+    # api url for each service will be taken from catalog,
+    # but you may pass `api_url` param to force custom url eg.
+    # nova = NovaClient(session=auth, api_url='http://my-local-nova:9876/v2/')
+
     await nova.init_api()
     await glance.init_api()
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(name):
 
 setup(
     name="AsyncOpenStackClient",
-    version="0.2.3",
+    version="0.3.0",
     author='Dreamlab - PaaS KRK',
     author_email='paas-support@dreamlab.pl',
     url='https://github.com/DreamLab/AsyncOpenStackClient',

--- a/src/asyncopenstackclient/glance.py
+++ b/src/asyncopenstackclient/glance.py
@@ -1,17 +1,6 @@
-import aiohttp
 from .client import Client
 
 
 class GlanceClient(Client):
-    def __init__(self, api_version=None, session=None):
-        super().__init__('glance', ['images'], api_version, session)
-
-    async def get_api_url_with_version(self, glance_url):
-        async with aiohttp.ClientSession() as session:
-            async with session.get(glance_url) as response:
-                versions = await response.json()
-                return [version["links"][0]["href"] for version in versions["versions"] if version["status"] == "CURRENT"][0]
-
-    async def get_credentials(self):
-        await super().get_credentials()
-        self.api_url = await self.get_api_url_with_version(self.api_url)
+    def __init__(self, session=None, api_url=None):
+        super().__init__('glance', ['images'], session, api_url)

--- a/src/asyncopenstackclient/nova.py
+++ b/src/asyncopenstackclient/nova.py
@@ -2,8 +2,8 @@ from .client import Client
 
 
 class NovaClient(Client):
-    def __init__(self, api_version=None, session=None):
-        super().__init__('nova', ['flavors', 'servers'], api_version, session)
+    def __init__(self, session=None, api_url=None):
+        super().__init__('nova', ['flavors', 'servers'], session, api_url)
 
     async def init_api(self):
         await super().init_api()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -34,7 +34,7 @@ class TestClient(AsyncTestCase):
 
         client = Client('glance', ['some_res'], session=self.mock_sess)
 
-        # this is not good practice but the simplest one
+        # this is not a good practice but the simplest one
         client.get_current_version_api_url = mock.Mock(return_value=futurized('http://blah'))
 
         await client.get_credentials()
@@ -48,7 +48,7 @@ class TestClient(AsyncTestCase):
 
         client = Client('glance', ['some_res'], session=self.mock_sess)
 
-        # this is not good practice but the simplest one
+        # this is not a good practice but the simplest one
         client.get_current_version_api_url = mock.Mock(return_value=futurized('http://blah'))
 
         await client.get_credentials()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,7 +6,11 @@ from unittest import mock
 class TestClient(AsyncTestCase):
 
     def setUp(self):
-        pass
+        super().setUp()
+        self.mock_sess = mock.Mock()
+        self.mock_sess.authenticate.return_value = futurized(None)
+        self.mock_sess.token = 'mock_token'
+        self.mock_sess.get_endpoint_url.return_value = 'mock_url'
 
     def tearDown(self):
         mock.patch.stopall()
@@ -14,44 +18,62 @@ class TestClient(AsyncTestCase):
     def test_create_object(self):
         api_name = 'mock_api'
         resources = 'mock_resource'
-        api_version = 'mock_api_version'
         session = 'mock_session'
-        client = Client(api_name, resources, api_version=api_version, session=session)
+        client = Client(api_name, resources, session=session)
 
         self.assertEqual(client.api_name, api_name)
-        self.assertEqual(client.api_version, api_version)
         self.assertEqual(client.resources, resources)
         self.assertEqual(client.session, session)
 
     def test_create_object_bad_session(self):
         with self.assertRaises(AttributeError):
-            Client('mock_name', 'mock_version', session=None)
+            Client('mock_name', 'resource', session=None)
 
     async def test_get_credentials(self):
-        session = mock.Mock()
-        session.authenticate.return_value = futurized(None)
-        session.get_endpoint_url.return_value = "mock_url"
+        self.mock_sess.get_endpoint_url.return_value = 'http://glance.a2.iaas:9292/v2'
 
-        client = Client("mock_name", "mock_version", session=session)
+        client = Client('glance', ['some_res'], session=self.mock_sess)
+
+        # this is not good practice but the simplest one
+        client.get_current_version_api_url = mock.Mock(return_value=futurized('http://blah'))
+
         await client.get_credentials()
 
-        self.assertEqual(client.api_url, "mock_url")
+        client.get_current_version_api_url.assert_not_called()
+        self.mock_sess.get_endpoint_url.assert_called_once_with('glance')
+        self.assertEqual(client.api_url, 'http://glance.a2.iaas:9292/v2')
+
+    async def test_get_credentials_base_api_url_only_from_catalog(self):
+        self.mock_sess.get_endpoint_url.return_value = 'http://glance.a2.iaas:9292'
+
+        client = Client('glance', ['some_res'], session=self.mock_sess)
+
+        # this is not good practice but the simplest one
+        client.get_current_version_api_url = mock.Mock(return_value=futurized('http://blah'))
+
+        await client.get_credentials()
+
+        self.mock_sess.get_endpoint_url.assert_called_once_with('glance')
+        client.get_current_version_api_url.assert_called_once_with('http://glance.a2.iaas:9292')
+        self.assertEqual(client.api_url, 'http://blah')
+
+    async def test_custom_api_url(self):
+        client = Client('mock_name', 'some_res', session=self.mock_sess, api_url="http://my-api-url/")
+        await client.get_credentials()
+
+        self.mock_sess.get_endpoint_url.assert_not_called()
+        self.assertEqual(client.api_url, 'http://my-api-url/')
 
     async def test_init_api(self):
-        session = mock.Mock()
-        session.authenticate.return_value = futurized(None)
-        session.get_endpoint_url.return_value = "mock_url"
-        session.token = 'mock_token'
         mock_api = mock.Mock()
-
         mock.patch('asyncopenstackclient.client.API', new_callable=mock_api).start()
 
-        client = Client("mock_name", ['mock', 'resource', 'list'], session=session)
+        client = Client('mock_name', ['mock', 'resource', 'list'], session=self.mock_sess)
         await client.init_api()
 
         mock_api().assert_called_once_with(
-            api_root_url="mock_url",
-            headers={"X-Auth-Token": 'mock_token'},
+            api_root_url='mock_url',
+            headers={'X-Auth-Token': 'mock_token'},
             json_encode_body=True
         )
 


### PR DESCRIPTION
Added:

- api_url to Client's init - allows to force api url
- determine api_url (fetch version) in Client (not only glance)

Removed:

- api_version from Client - unsed