### PR TITLE
Feature/more natural api

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.6.0 (2018-05-01)
+------------------
+
+* Feature: wrap requests with Resource/Method proxy
+
+
 0.5.1 (2018-04-29)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ AsyncOpenStackClient
 Introduction
 ============
 
-The `AsyncOpenStackClient` is a rest wrapper for the OpenStack API. It provides very raw functionality; however, it has a nice abstraction for authentication. For method specification, see the official OpenStack documentation: https://docs.openstack.org/queens/api/.
+The `AsyncOpenStackClient` is a asynchronous rest wrapper for the OpenStack API. It provides a nice abstraction for authentication and wraps some (not all of them) methods for the OpenStack Compute API. For method specification, see the official OpenStack documentation: https://docs.openstack.org/queens/api/.
 
 
 Installation
@@ -25,9 +25,6 @@ Use pip:
 
 Usage
 =====
-
-As mentioned above, this is a "raw" library, so you must handle `params` and/or `body` and the `response`.
-
 
 .. code-block:: python
 
@@ -54,21 +51,19 @@ As mentioned above, this is a "raw" library, so you must handle `params` and/or 
     await glance.init_api()
 
 
-    servers = await nova.api.servers.list(params={'name': 'testvm'})
-    vm = await nova.api.servers.get(id)
+    servers = await nova.servers.list(name='testvm')
+    vm = await nova.servers.get(server_id)
 
 
-    body = {
-        "server": {
-            "name": 'some_name',
-            "flavorRef": 'flavor_id',
-            "imageRef": 'image_id',
-            "security_groups": [{'name': 'group1'}, {'name': 'group2'}]
-            "user_data": base64.b64encode(userdata).decode('utf-8')
-        }
+    specs = {
+        "name": 'some_name',
+        "flavorRef": 'flavor_id',
+        "imageRef": 'image_id',
+        "security_groups": [{'name': 'group1'}, {'name': 'group2'}]
+        "user_data": base64.b64encode(userdata).decode('utf-8')
     }
-    response = await nova.api.servers.create(body=body)
-    print(response.body)
+    response = await nova.servers.create(server=specs)
+    print(response)
 
 
 Available functions
@@ -76,15 +71,15 @@ Available functions
 
 - Nova (https://developer.openstack.org/api-ref/compute)
 
-  - servers.list(params)  # params optional
+  - servers.list(optional=filter)  # params optional
   - servers.get(id)
-  - servers.create(body)
+  - servers.create(server=server_spec)
   - servers.force_delete(id)
   - flavors.list()
   - metadata.get(server_id)
-  - metadata.set(server_id)
+  - metadata.set(server_id, meta=meta_spec)
   - metadata.get_item(server_id, item_name)
-  - metadata.set_item(server_id, item_name)
+  - metadata.set_item(server_id, item_name, meta=meta_spec)
 
 - Glance (https://developer.openstack.org/api-ref/image/v2/index.html)
 

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ AsyncOpenStackClient
 Introduction
 ============
 
-The `AsyncOpenStackClient` is a asynchronous rest wrapper for the OpenStack API. It provides a nice abstraction for authentication and wraps some (not all of them) methods for the OpenStack Compute API. For method specification, see the official OpenStack documentation: https://docs.openstack.org/queens/api/.
+The `AsyncOpenStackClient` is a asynchronous rest wrapper for the OpenStack API. It provides a nice abstraction for authentication. For method specification, see the official OpenStack documentation: https://docs.openstack.org/queens/api/.
 
 
 Installation

--- a/src/asyncopenstackclient/client.py
+++ b/src/asyncopenstackclient/client.py
@@ -3,6 +3,8 @@ from simple_rest_client.api import API
 from simple_rest_client.resource import AsyncResource
 from urllib.parse import urlparse
 
+from .proxy import ResourceProxy
+
 
 class Client:
 
@@ -52,3 +54,6 @@ class Client:
         else:
             # base url so we need to determine full url with version
             self._current_api_url = await self.get_current_version_api_url(url)
+
+    def __getattr__(self, name):
+        return ResourceProxy(self.api, name)

--- a/src/asyncopenstackclient/proxy.py
+++ b/src/asyncopenstackclient/proxy.py
@@ -1,0 +1,31 @@
+class ResourceProxy:
+
+    def __init__(self, api, resource_name):
+        self.resource_name = resource_name
+        self.api = api
+
+    def __getattr__(self, name):
+        return MethodProxy(self.api, self.resource_name, name)
+
+
+class MethodProxy:
+
+    def __init__(self, api, resource, method):
+        self.api = api
+        self.resource = resource
+        self.method = method
+
+    def __call__(self, *args, **kwargs):
+        return self.__await__(*args, **kwargs)
+
+    def __await__(self, *args, **kwargs):
+        resource = getattr(self.api, self.resource)
+        method = getattr(resource, self.method)
+        if resource.actions[self.method]['method'] in ('GET',):
+            return self.get_result(method(*args, params=kwargs))
+        else:
+            return self.get_result(method(*args, body=kwargs))
+
+    async def get_result(self, method_awaitable):
+        result = await method_awaitable
+        return result.body

--- a/src/asyncopenstackclient/proxy.py
+++ b/src/asyncopenstackclient/proxy.py
@@ -16,9 +16,6 @@ class MethodProxy:
         self.method = method
 
     def __call__(self, *args, **kwargs):
-        return self.__await__(*args, **kwargs)
-
-    def __await__(self, *args, **kwargs):
         resource = getattr(self.api, self.resource)
         method = getattr(resource, self.method)
         if resource.actions[self.method]['method'] in ('GET',):

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,95 @@
+from aiounittest import AsyncTestCase, futurized
+from asyncopenstackclient.proxy import ResourceProxy, MethodProxy
+from unittest.mock import Mock, patch
+
+
+class MockClass:
+
+    def __init__(self, api='mock-api'):
+        self.api = api
+
+    def __getattr__(self, name):
+        return ResourceProxy(self.api, name)
+
+
+class TestClient(AsyncTestCase):
+
+    def setUp(self):
+        super().setUp()
+
+    def tearDown(self):
+        patch.stopall()
+
+    def test_pass_arguments_resource_proxy(self):
+        res = ResourceProxy('mock-api', 'mock-resource')
+
+        self.assertEqual(res.api, 'mock-api')
+        self.assertEqual(res.resource_name, 'mock-resource')
+        self.assertIsInstance(res.not_existing_property, MethodProxy)
+
+    def test_resouce_proxy_return_method_proxy(self):
+        mock_method_proxy = patch('asyncopenstackclient.proxy.MethodProxy').start()
+        res = ResourceProxy('mock-api', 'mock-resource')
+        res.mock_method()
+
+        mock_method_proxy.assert_called_once_with('mock-api', 'mock-resource', 'mock_method')
+
+    def test_resource_proxy_from_mock_class(self):
+        mock_method_proxy = patch('asyncopenstackclient.proxy.MethodProxy').start()
+        obj = MockClass()
+
+        res = obj.servers.list()
+
+        mock_method_proxy.assert_called_once_with('mock-api', 'servers', 'list')
+        self.assertEqual(res, mock_method_proxy()())
+
+    def test_pass_arguments_method_proxy(self):
+        res = MethodProxy('mock-api', 'mock-resource', 'mock-method')
+
+        self.assertEqual(res.api, 'mock-api')
+        self.assertEqual(res.resource, 'mock-resource')
+        self.assertEqual(res.method, 'mock-method')
+
+    async def test_get_result_method_proxy(self):
+        res_mock = Mock()
+        res_mock.body = 'awesome_body'
+        awaitable = futurized(res_mock)
+        proxy = MethodProxy('api', 'resource', 'method')
+
+        result = await proxy.get_result(awaitable)
+
+        self.assertEqual(result, 'awesome_body')
+
+    async def test_call_method_proxy_with_query_params(self):
+        mock_args = ('a', 'b',)
+        mock_kwargs = {'k1': 'v1'}
+        mock_api = Mock()
+        mock_api.servers = Mock()
+        mock_api.servers.list = Mock()
+        mock_res = Mock()
+        mock_res.body = 'return_value'
+        mock_api.servers.list.return_value = futurized(mock_res)
+        mock_api.servers.actions = {'list': {'method': 'GET'}}
+
+        obj = MockClass(api=mock_api)
+        res = await obj.servers.list(*mock_args, **mock_kwargs)
+
+        self.assertEqual(res, 'return_value')
+        mock_api.servers.list.assert_called_once_with(*mock_args, params=mock_kwargs)
+
+    async def test_call_method_proxy_with_body(self):
+        mock_args = ('a', 'b',)
+        mock_kwargs = {'k1': 'v1'}
+        mock_api = Mock()
+        mock_api.servers = Mock()
+        mock_api.servers.create = Mock()
+        mock_res = Mock()
+        mock_res.body = 'return_value'
+        mock_api.servers.create.return_value = futurized(mock_res)
+        mock_api.servers.actions = {'create': {'method': 'POST'}}
+
+        obj = MockClass(api=mock_api)
+        res = await obj.servers.create(*mock_args, **mock_kwargs)
+
+        self.assertEqual(res, 'return_value')
+        mock_api.servers.create.assert_called_once_with(*mock_args, body=mock_kwargs)


### PR DESCRIPTION
This PR provides more natural way to interact with OS api. From now on, there is no need to provide `body` and `params` as kwargs, one need to pass its parameters via `args` and `kwargs`. To achieve that, `ResourceProxy` and `MethodProxy` has been implemented. 