### PR TITLE
Bugfix/init property to get more accurate error and upgrade dep

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 0.6.0 (2018-05-12)
 ------------------
 
-* Bugfix: initial field (api) in Client to get some meaningful error instead of "recursion limit reached".
+* Bugfix: initialize property (api) in Client to get some meaningful error instead of "recursion limit reached".
 
 
 0.6.0 (2018-05-12)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 0.6.0 (2018-05-12)
 ------------------
 
+* Bugfix: initial field (api) in Client to get some meaningful error instead of "recursion limit reached".
+
+
+0.6.0 (2018-05-12)
+------------------
+
 * Feature: wrap requests with Resource/Method proxy
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.0.0
+aiohttp>=3
 simplejson==3.13.2
 simple-rest-client==0.5.1
 python-dateutil==2.7.2

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(name):
 
 setup(
     name="AsyncOpenStackClient",
-    version="0.6.0",
+    version="0.6.1",
     author='Dreamlab - PaaS KRK',
     author_email='paas-support@dreamlab.pl',
     url='https://github.com/DreamLab/AsyncOpenStackClient',

--- a/src/asyncopenstackclient/client.py
+++ b/src/asyncopenstackclient/client.py
@@ -1,9 +1,8 @@
 import aiohttp
+from .proxy import ResourceProxy
 from simple_rest_client.api import API
 from simple_rest_client.resource import AsyncResource
 from urllib.parse import urlparse
-
-from .proxy import ResourceProxy
 
 
 class Client:
@@ -15,6 +14,7 @@ class Client:
         self._custom_api_url = api_url
         self._catalog_api_url = None
         self._current_api_url = None
+        self.api = None
         if self.session is None:
             raise AttributeError("provided session object is None, probably auth error?")
 


### PR DESCRIPTION
Changes:
- initial field (api) in Client to get some meaningful error instead of "recursion limit reached"
- loosy dependences (aiohttp)