### PR TITLE
Increase simplerest_client timeout from 2 (defautl) to 60 seconds

### DIFF
--- a/src/asyncopenstackclient/client.py
+++ b/src/asyncopenstackclient/client.py
@@ -18,12 +18,13 @@ class Client:
         if self.session is None:
             raise AttributeError("provided session object is None, probably auth error?")
 
-    async def init_api(self):
+    async def init_api(self, timeout=60):
         await self.get_credentials()
         self.api = API(
             api_root_url=self.api_url,
             headers={'X-Auth-Token': self.session.token},
-            json_encode_body=True
+            json_encode_body=True,
+            timeout=timeout
         )
         for resource in self.resources:
             self.api.add_resource(resource_name=resource, resource_class=AsyncResource)

--- a/src/asyncopenstackclient/nova.py
+++ b/src/asyncopenstackclient/nova.py
@@ -5,8 +5,8 @@ class NovaClient(Client):
     def __init__(self, session=None, api_url=None):
         super().__init__('nova', ['flavors', 'servers', 'metadata'], session, api_url)
 
-    async def init_api(self):
-        await super().init_api()
+    async def init_api(self, timeout=60):
+        await super().init_api(timeout)
         self.api.servers.actions["force_delete"] = {"method": "DELETE", "url": "servers/{}"}
         self.api.servers.actions["get"] = {"method": "GET", "url": "servers/{}"}
         self.api.servers.actions["list"] = {"method": "GET", "url": "servers/detail"}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -68,13 +68,16 @@ class TestClient(AsyncTestCase):
         mock_api = mock.Mock()
         mock.patch('asyncopenstackclient.client.API', new_callable=mock_api).start()
 
+        client_timeout = 30
+
         client = Client('mock_name', ['mock', 'resource', 'list'], session=self.mock_sess)
-        await client.init_api()
+        await client.init_api(timeout=client_timeout)
 
         mock_api().assert_called_once_with(
             api_root_url='mock_url/',
             headers={'X-Auth-Token': 'mock_token'},
-            json_encode_body=True
+            json_encode_body=True,
+            timeout=client_timeout
         )
 
         mock_api()().add_resource.assert_has_calls([


### PR DESCRIPTION
Hi folks,

according to https://python-simple-rest-client.readthedocs.io/en/0.5.0/quickstart.html

`>>> api = API(
...     api_root_url='https://reqres.in/api/', # base api url
...     params={}, # default params
...     headers={}, # default headers
...     timeout=2, # default timeout in seconds
...     append_slash=False, # append slash to final url
...     json_encode_body=True, # encode body as json
... )`

the default timeout is incredible low (only 2 seconds), which leads to frequent timeouts when using your really nice client. 
Therefore, I would propose to increase the timeout to more reasonable 60 seconds by accepting the this pull request.

Thank you very much and kind regards,
Manuel