### PR TITLE
Bump simple-rest-client to version 0.5.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 aiohttp>=3
 simplejson==3.13.2
-simple-rest-client==0.5.1
+simple-rest-client==0.5.2
 python-dateutil==2.7.2


### PR DESCRIPTION
Hi folks,

#19 is already fixed upstream in simple-rest-client version 0.5.2. By accepting this pull request, the required simple-rest-client version will be bumped to 0.5.2.

Thank you  and kind regards,
Manuel