### PR TITLE
Cinder implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.project
 /.pydevproject
 **/*.orig
+.idea
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Usage
 
 .. code-block:: python
 
-    from asyncopenstackclient import NovaClient, GlanceClient, AuthPassword
+    from asyncopenstackclient import NovaClient, GlanceClient, CinderClient, AuthPassword
 
     # you can either pass credentials explicitly (as shown below)
     # or use enviormental variables from OpenStack RC file
@@ -42,6 +42,7 @@ Usage
     )
     nova = NovaClient(session=auth)
     glance = GlanceClient(session=auth)
+    cinder = CinderClient(session=auth)
 
     # api url for each service will be taken from catalog,
     # but you may pass `api_url` param to force custom url eg.
@@ -49,6 +50,7 @@ Usage
 
     await nova.init_api()
     await glance.init_api()
+    await cinder.init_api()
 
 
     servers = await nova.servers.list(name='testvm')
@@ -65,6 +67,12 @@ Usage
     response = await nova.servers.create(server=specs)
     print(response)
 
+    volume = {"size": 200,
+              "imageRef": "image_id",
+              "name": "some_name"}
+
+    response = await cinder.volumes.create(volume=volume)
+    print(response)
 
 Available functions
 -------------------
@@ -84,6 +92,13 @@ Available functions
 - Glance (https://developer.openstack.org/api-ref/image/v2/index.html)
 
   - images.list()
+
+- Cinder (https://developer.openstack.org/api-ref/block-storage/v3/index.html)
+
+  - volumes.list(optional=filter)  # params optional
+  - volumes.get(id)
+  - volumes.create(volume=volume_spec)
+  - volumes.force_delete(id)
 
 
 License

--- a/src/asyncopenstackclient/cinder.py
+++ b/src/asyncopenstackclient/cinder.py
@@ -1,0 +1,14 @@
+from .client import Client
+
+
+class CinderClient(Client):
+    def __init__(self, session=None, api_url=None):
+        super().__init__('cinder', ['volumes'], session, api_url)
+
+    async def init_api(self, timeout=60):
+        await super().init_api(timeout)
+        self.api.volumes.actions["force_delete"] = {"method": "DELETE", "url": "volumes/{}"}
+        self.api.volumes.actions["get"] = {"method": "GET", "url": "volumes/{}"}
+        self.api.volumes.actions["list"] = {"method": "GET", "url": "volumes/detail"}
+        self.api.volumes.add_action("force_delete")
+        self.api.volumes.add_action("get")

--- a/src/asyncopenstackclient/client.py
+++ b/src/asyncopenstackclient/client.py
@@ -22,7 +22,10 @@ class Client:
         await self.get_credentials()
         self.api = API(
             api_root_url=self.api_url,
-            headers={'X-Auth-Token': self.session.token},
+            headers={'X-Auth-Token': self.session.token,
+                     'Accept': 'application/json',
+                     'Content-Type': 'application/json'
+                     },
             json_encode_body=True,
             timeout=timeout
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -75,7 +75,10 @@ class TestClient(AsyncTestCase):
 
         mock_api().assert_called_once_with(
             api_root_url='mock_url/',
-            headers={'X-Auth-Token': 'mock_token'},
+            headers={'X-Auth-Token': 'mock_token',
+                     'Accept': 'application/json',
+                     'Content-Type': 'application/json'
+                     },
             json_encode_body=True,
             timeout=client_timeout
         )


### PR DESCRIPTION
Hi folks,

thank you for the fast response to my last requests. However, I have a few more things I would like to add to your async OpenStack client.

1. Seems that Accept and Content Type headers are missing in the client. (see https://github.com/DreamLab/AsyncOpenStackClient/commit/34f648dbcc131756ce3d2c53ed5bdd5d589d21fc)

2. In case you are interested to support also the volumes API of Cinder, please have a look at https://github.com/DreamLab/AsyncOpenStackClient/commit/ac62956b8610d734c4e8de1eb529655429c2f74c.

I would really appreciate if you consider to merge this request as well. 

Thanks and best regards,
Manuel