### PR TITLE
Add run server action call to nova client

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,9 @@ Usage
     servers = await nova.servers.list(name='testvm')
     vm = await nova.servers.get(server_id)
 
+    action_spec = {'os-stop': None}
+    await nova.servers.run_action(server_id, **action_spec)
+
 
     specs = {
         "name": 'some_name',
@@ -87,6 +90,7 @@ Available functions
   - servers.get(id)
   - servers.create(server=server_spec)
   - servers.force_delete(id)
+  - servers.run_action(id, action=action_spec)
   - flavors.list()
   - metadata.get(server_id)
   - metadata.set(server_id, meta=meta_spec)

--- a/src/asyncopenstackclient/nova.py
+++ b/src/asyncopenstackclient/nova.py
@@ -10,8 +10,10 @@ class NovaClient(Client):
         self.api.servers.actions["force_delete"] = {"method": "DELETE", "url": "servers/{}"}
         self.api.servers.actions["get"] = {"method": "GET", "url": "servers/{}"}
         self.api.servers.actions["list"] = {"method": "GET", "url": "servers/detail"}
+        self.api.servers.actions["run_action"] = {"method": "POST", "url": "servers/{}/action"}
         self.api.servers.add_action("force_delete")
         self.api.servers.add_action("get")
+        self.api.servers.add_action("run_action")
         self.api.flavors.actions["list"] = {"method": "GET", "url": "flavors/detail"}
         self.api.metadata.actions['get'] = {"method": "GET", "url": "servers/{}/metadata"}
         self.api.metadata.actions['set'] = {"method": "POST", "url": "servers/{}/metadata"}


### PR DESCRIPTION
Hi folks,

I have add support to run server action calls (https://developer.openstack.org/api-ref/compute/#servers-run-an-action-servers-action) to the nova client api and added documentation about how to use this feature. 

I would really appreciate if you consider to merge this request.

Thanks and best regards,
Manuel